### PR TITLE
Functions that do not take parameters do not return functions anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Should sum an array or iterator.
 ```js
 import { pipe, sum } from 'lazy-collections';
 
-let program = pipe(sum());
+let program = pipe(sum);
 
 program([1, 1, 2, 3, 2, 4, 5]);
 // 18

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Reverses the iterator.
 ```js
 import { pipe, reverse, toArray } from 'lazy-collections';
 
-let program = pipe(range(0, 5), reverse(), toArray);
+let program = pipe(range(0, 5), reverse, toArray);
 
 program();
 // [ 5, 4, 3, 2, 1, 0 ]

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ Zips multiple arrays / iterators together.
 ```js
 import { pipe, zip, toArray } from 'lazy-collections';
 
-let program = pipe(zip(), toArray);
+let program = pipe(zip, toArray);
 
 program([
   [0, 1, 2],

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Find the maximum value of the given list
 ```js
 import { pipe, range, max } from 'lazy-collections';
 
-let program = pipe(range(0, 5), max());
+let program = pipe(range(0, 5), max);
 
 program();
 // 5

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let program = pipe(
   filter(x => x % 4 === 0),
   filter(x => x % 100 === 0),
   filter(x => x % 400 === 0),
-  toArray()
+  toArray
 );
 
 program(range(0, 1000000));
@@ -113,7 +113,7 @@ let program = pipe(
   filter(x => x % 400 === 0),
   takeWhile(x => x < 1_000),
   slice(0, 1_000),
-  toArray()
+  toArray
 );
 
 program(); // [ 0, 400, 800 ]
@@ -202,7 +202,7 @@ import { pipe, concat, toArray } from 'lazy-collections';
 
 let program = pipe(
   concat([0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10]),
-  toArray()
+  toArray
 );
 
 program();
@@ -235,7 +235,7 @@ import { pipe, filter, toArray } from 'lazy-collections';
 
 let program = pipe(
   filter(x => x % 2 === 0),
-  toArray()
+  toArray
 );
 
 program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
@@ -309,7 +309,7 @@ import { pipe, map, toArray } from 'lazy-collections';
 
 let program = pipe(
   map(x => x * 2),
-  toArray()
+  toArray
 );
 
 program([1, 2, 3]);
@@ -343,7 +343,7 @@ Reverses the iterator.
 ```js
 import { pipe, reverse, toArray } from 'lazy-collections';
 
-let program = pipe(range(0, 5), reverse(), toArray());
+let program = pipe(range(0, 5), reverse(), toArray);
 
 program();
 // [ 5, 4, 3, 2, 1, 0 ]
@@ -439,7 +439,7 @@ Chunk the data into pieces of a certain size.
 ```js
 import { pipe, chunk, toArray } from 'lazy-collections';
 
-let program = pipe(chunk(3), toArray());
+let program = pipe(chunk(3), toArray);
 
 program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 // [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10 ] ];
@@ -454,7 +454,7 @@ Filters out all falsey values.
 ```js
 import { pipe, compact, toArray } from 'lazy-collections';
 
-let program = pipe(compact(), toArray());
+let program = pipe(compact(), toArray);
 
 program([0, 1, true, false, null, undefined, '', 'test', NaN]);
 // [ 1, true, 'test' ];
@@ -474,7 +474,7 @@ let program = pipe(
   range(0, 4),
   delay(5000), // 5 seconds
   map(() => new Date().toLocaleTimeString()),
-  toArray()
+  toArray
 );
 
 await program();
@@ -490,7 +490,7 @@ By default we will flatten recursively deep.
 ```js
 import { pipe, flatten, toArray } from 'lazy-collections';
 
-let program = pipe(flatten(), toArray());
+let program = pipe(flatten(), toArray);
 
 program([1, 2, 3, [4, 5, 6, [7, 8], 9, 10]]);
 // [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
@@ -501,7 +501,7 @@ But you can also just flatten shallowly
 ```js
 import { pipe, flatten, toArray } from 'lazy-collections';
 
-let program = pipe(flatten({ shallow: true }), toArray());
+let program = pipe(flatten({ shallow: true }), toArray);
 
 program([1, 2, 3, [4, 5, 6, [7, 8], 9, 10]]);
 // [ 1, 2, 3, 4, 5, 6, [ 7, 8 ], 9, 10 ]
@@ -518,7 +518,7 @@ will end. For example, you can use `take`, `takeWhile` or `slice`.
 ```js
 import { pipe, generate, take, toArray } from 'lazy-collections';
 
-let program = pipe(generate(Math.random), take(3), toArray());
+let program = pipe(generate(Math.random), take(3), toArray);
 
 program();
 // [ 0.7495421596380878, 0.09819118640607383, 0.2453718461872143 ]
@@ -583,7 +583,7 @@ import { pipe, partition, range, toArray } from 'lazy-collections';
 let program = pipe(
   range(1, 4),
   partition(x => x % 2 !== 0),
-  toArray()
+  toArray
 );
 
 program();
@@ -600,7 +600,7 @@ optional and defaults to `1`.
 ```js
 import { pipe, range, toArray } from 'lazy-collections';
 
-let program = pipe(range(5, 20, 5), toArray());
+let program = pipe(range(5, 20, 5), toArray);
 
 program();
 // [ 5, 10, 15, 20 ]
@@ -615,7 +615,7 @@ Allows you to skip X values of the input.
 ```js
 import { pipe, range, skip, toArray } from 'lazy-collections';
 
-let program = pipe(range(0, 10), skip(3), toArray());
+let program = pipe(range(0, 10), skip(3), toArray);
 
 program();
 // [ 3, 4, 5, 6, 7, 8, 9, 10 ]
@@ -631,7 +631,7 @@ index.
 ```js
 import { pipe, range, slice, toArray } from 'lazy-collections';
 
-let program = pipe(range(0, 10), slice(3, 5), toArray());
+let program = pipe(range(0, 10), slice(3, 5), toArray);
 
 program();
 // [ 3, 4, 5 ]
@@ -649,7 +649,7 @@ Allows you to take X values of the input.
 ```js
 import { pipe, range, take, toArray } from 'lazy-collections';
 
-let program = pipe(range(0, 10), take(3), toArray());
+let program = pipe(range(0, 10), take(3), toArray);
 
 program();
 // [ 1, 2, 3 ]
@@ -668,7 +668,7 @@ import { pipe, range, takeWhile, toArray } from 'lazy-collections';
 let program = pipe(
   range(0, 10),
   takeWhile(x => x < 5),
-  toArray()
+  toArray
 );
 
 program();
@@ -689,7 +689,7 @@ let program = pipe(
   tap(x => {
     console.log('x:', x);
   }),
-  toArray()
+  toArray
 );
 
 program();
@@ -711,7 +711,7 @@ Converts an array or an iterator to an actual array.
 ```js
 import { pipe, range, toArray } from 'lazy-collections';
 
-let program = pipe(range(0, 10), toArray());
+let program = pipe(range(0, 10), toArray);
 
 program();
 // [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
@@ -726,7 +726,7 @@ Make your data unique.
 ```js
 import { pipe, unique, toArray } from 'lazy-collections';
 
-let program = pipe(unique(), toArray());
+let program = pipe(unique(), toArray);
 
 program([1, 1, 2, 3, 2, 4, 5]);
 // [ 1, 2, 3, 4, 5 ]
@@ -745,7 +745,7 @@ let program = pipe(
   range(15, 20),
   map(age => ({ age })),
   where({ age: 18 }),
-  toArray()
+  toArray
 );
 
 program();
@@ -761,7 +761,7 @@ Zips multiple arrays / iterators together.
 ```js
 import { pipe, zip, toArray } from 'lazy-collections';
 
-let program = pipe(zip(), toArray());
+let program = pipe(zip(), toArray);
 
 program([
   [0, 1, 2],

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ value.
 ```js
 import { pipe, chunk, toArray } from 'lazy-collections';
 
-let program = pipe(head());
+let program = pipe(head);
 
 program([6, 7, 8, 9, 10]);
 // 6

--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ Make your data unique.
 ```js
 import { pipe, unique, toArray } from 'lazy-collections';
 
-let program = pipe(unique(), toArray);
+let program = pipe(unique, toArray);
 
 program([1, 1, 2, 3, 2, 4, 5]);
 // [ 1, 2, 3, 4, 5 ]

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Find the minimum value of the given list
 ```js
 import { pipe, range, min } from 'lazy-collections';
 
-let program = pipe(range(5, 10), min());
+let program = pipe(range(5, 10), min);
 
 program();
 // 5

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Gets the average of number of values.
 ```js
 import { pipe, average, toArray } from 'lazy-collections';
 
-let program = pipe(average());
+let program = pipe(average);
 
 program([6, 7, 8, 9, 10]);
 // 8

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Filters out all falsey values.
 ```js
 import { pipe, compact, toArray } from 'lazy-collections';
 
-let program = pipe(compact(), toArray);
+let program = pipe(compact, toArray);
 
 program([0, 1, true, false, null, undefined, '', 'test', NaN]);
 // [ 1, true, 'test' ];

--- a/src/average.test.ts
+++ b/src/average.test.ts
@@ -3,21 +3,21 @@ import { average } from './average'
 import { delay } from './delay'
 
 it('should be possible to get an average of all the values', () => {
-  let program = pipe(average())
+  let program = pipe(average)
 
   expect(program([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(5)
   expect(program([10, 10, 10])).toEqual(10)
 })
 
 it('should be possible to get an average of all the values (async)', async () => {
-  let program = pipe(delay(0), average())
+  let program = pipe(delay(0), average)
 
   expect(await program([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(5)
   expect(await program([10, 10, 10])).toEqual(10)
 })
 
 it('should be possible to get an average of all the values (Promise async)', async () => {
-  let program = pipe(average())
+  let program = pipe(average)
 
   expect(await program(Promise.resolve([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toEqual(5)
   expect(await program(Promise.resolve([10, 10, 10]))).toEqual(10)

--- a/src/average.ts
+++ b/src/average.ts
@@ -5,8 +5,7 @@ import { head } from './head'
 import { pipe } from './pipe'
 import { LazyIterable } from './shared-types'
 
-export function average() {
-  return function averageFn(data: LazyIterable<number>) {
+export function average(data: LazyIterable<number>) {
     let program = pipe(
       reduce<[number, number], number>(
         (acc, current) => {
@@ -22,7 +21,6 @@ export function average() {
     )
 
     return program(data)
-  }
 }
 
 // Alias

--- a/src/average.ts
+++ b/src/average.ts
@@ -18,7 +18,7 @@ export function average() {
       ),
       chunk(2),
       map(([sum, count]: [number, number]) => sum / count),
-      head()
+      head
     )
 
     return program(data)

--- a/src/chunk.test.ts
+++ b/src/chunk.test.ts
@@ -5,7 +5,7 @@ import { toArray } from './toArray'
 import { delay } from './delay'
 
 it('should create chunked items', () => {
-  let program = pipe(chunk(3), toArray())
+  let program = pipe(chunk(3), toArray)
 
   expect(program(range(0, 10))).toEqual([
     [0, 1, 2],
@@ -22,7 +22,7 @@ it('should create chunked items', () => {
 })
 
 it('should create chunked items (async)', async () => {
-  let program = pipe(delay(0), chunk(3), toArray())
+  let program = pipe(delay(0), chunk(3), toArray)
 
   expect(await program(range(0, 10))).toEqual([
     [0, 1, 2],
@@ -39,7 +39,7 @@ it('should create chunked items (async)', async () => {
 })
 
 it('should create chunked items (Promise async)', async () => {
-  let program = pipe(chunk(3), toArray())
+  let program = pipe(chunk(3), toArray)
 
   expect(await program(Promise.resolve(range(0, 10)))).toEqual([
     [0, 1, 2],

--- a/src/compact.test.ts
+++ b/src/compact.test.ts
@@ -4,14 +4,14 @@ import { toArray } from './toArray'
 import { delay } from './delay'
 
 it('should remove all falsey values', () => {
-  let program = pipe(compact(), toArray())
+  let program = pipe(compact(), toArray)
 
   expect(program([0, 1, true, false, null, undefined, '', 'test', NaN])).toEqual([1, true, 'test'])
   expect(program([0, 1, true, false, null, undefined, '', 'test', NaN])).toEqual([1, true, 'test'])
 })
 
 it('should remove all falsey values (async)', async () => {
-  let program = pipe(delay(0), compact(), toArray())
+  let program = pipe(delay(0), compact(), toArray)
 
   expect(await program([0, 1, true, false, null, undefined, '', 'test', NaN])).toEqual([
     1,
@@ -26,7 +26,7 @@ it('should remove all falsey values (async)', async () => {
 })
 
 it('should remove all falsey values (Promise async)', async () => {
-  let program = pipe(compact(), toArray())
+  let program = pipe(compact(), toArray)
 
   expect(
     await program(Promise.resolve([0, 1, true, false, null, undefined, '', 'test', NaN]))

--- a/src/compact.test.ts
+++ b/src/compact.test.ts
@@ -4,14 +4,14 @@ import { toArray } from './toArray'
 import { delay } from './delay'
 
 it('should remove all falsey values', () => {
-  let program = pipe(compact(), toArray)
+  let program = pipe(compact, toArray)
 
   expect(program([0, 1, true, false, null, undefined, '', 'test', NaN])).toEqual([1, true, 'test'])
   expect(program([0, 1, true, false, null, undefined, '', 'test', NaN])).toEqual([1, true, 'test'])
 })
 
 it('should remove all falsey values (async)', async () => {
-  let program = pipe(delay(0), compact(), toArray)
+  let program = pipe(delay(0), compact, toArray)
 
   expect(await program([0, 1, true, false, null, undefined, '', 'test', NaN])).toEqual([
     1,
@@ -26,7 +26,7 @@ it('should remove all falsey values (async)', async () => {
 })
 
 it('should remove all falsey values (Promise async)', async () => {
-  let program = pipe(compact(), toArray)
+  let program = pipe(compact, toArray)
 
   expect(
     await program(Promise.resolve([0, 1, true, false, null, undefined, '', 'test', NaN]))

--- a/src/compact.ts
+++ b/src/compact.ts
@@ -1,5 +1,6 @@
 import { filter } from './filter'
+import { LazyIterable } from './shared-types';
 
-export function compact<T>() {
-  return filter<T>(Boolean)
+export function compact<T>(data: LazyIterable<T>) {
+  return filter<T>(Boolean)(data)
 }

--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -15,7 +15,7 @@ it('should be possible to compose multiple functions', () => {
 })
 
 it('should be possible to pass a generator as first argument', () => {
-  let program = compose(toArray(), take(10), generate(Math.random))
+  let program = compose(toArray, take(10), generate(Math.random))
   let result = program()
   expect(result).toHaveLength(10)
 })

--- a/src/concat.test.ts
+++ b/src/concat.test.ts
@@ -5,25 +5,25 @@ import { toArray } from './toArray'
 import { delay } from './delay'
 
 it('should concat arrays', () => {
-  let program = pipe(concat([0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10]), toArray())
+  let program = pipe(concat([0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10]), toArray)
 
   expect(program()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })
 
 it('should concat iterators', () => {
-  let program = pipe(concat(range(0, 3), range(4, 7), range(8, 10)), toArray())
+  let program = pipe(concat(range(0, 3), range(4, 7), range(8, 10)), toArray)
 
   expect(program()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })
 
 it('should concat iterators (async)', async () => {
-  let program = pipe(concat(range(0, 3), delay(0)(range(4, 7)), range(8, 10)), toArray())
+  let program = pipe(concat(range(0, 3), delay(0)(range(4, 7)), range(8, 10)), toArray)
 
   expect(await program()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })
 
 it('should concat iterators (Promise async)', async () => {
-  let program = pipe(concat(range(0, 3), range(4, 7), Promise.resolve(range(8, 10))), toArray())
+  let program = pipe(concat(range(0, 3), range(4, 7), Promise.resolve(range(8, 10))), toArray)
 
   expect(await program()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -6,7 +6,7 @@ import { delay } from './delay'
 it('should be possible to filter data', () => {
   let program = pipe(
     filter((x: number) => x % 2 === 0), // Is even
-    toArray()
+    toArray
   )
 
   expect(program([1, 2, 3])).toEqual([2])
@@ -17,7 +17,7 @@ it('should be possible to filter data (async)', async () => {
   let program = pipe(
     delay(0),
     filter((x: number) => x % 2 === 0), // Is even
-    toArray()
+    toArray
   )
 
   expect(await program([1, 2, 3])).toEqual([2])
@@ -27,7 +27,7 @@ it('should be possible to filter data (async)', async () => {
 it('should be possible to filter data (Promise async)', async () => {
   let program = pipe(
     filter((x: number) => x % 2 === 0), // Is even
-    toArray()
+    toArray
   )
 
   expect(await program(Promise.resolve([1, 2, 3]))).toEqual([2])
@@ -37,7 +37,7 @@ it('should be possible to filter data (Promise async)', async () => {
 it('should take the index as second argument', async () => {
   let program = pipe(
     filter((_x: number, i) => i % 2 === 0), // Is even
-    toArray()
+    toArray
   )
 
   expect(await program(Promise.resolve([1, 2, 3]))).toEqual([1, 3])

--- a/src/flatten.test.ts
+++ b/src/flatten.test.ts
@@ -5,28 +5,28 @@ import { toArray } from './toArray'
 import { delay } from './delay'
 
 it('should be possible to flatten data (shallow)', () => {
-  let program = pipe(flatten({ shallow: true }), toArray())
+  let program = pipe(flatten({ shallow: true }), toArray)
 
   expect(program([1, [2], range(3, 10)])).toEqual(Array.from(range(1, 10)))
   expect(program([1, [2], range(3, 10)])).toEqual(Array.from(range(1, 10)))
 })
 
 it('should be possible to deep flatten data', () => {
-  let program = pipe(flatten(), toArray())
+  let program = pipe(flatten(), toArray)
 
   expect(program([1, [2, [3, [[[4]], [5]]]]])).toEqual(Array.from(range(1, 5)))
   expect(program([1, [2, [3, [[[4]], [5]]]]])).toEqual(Array.from(range(1, 5)))
 })
 
 it('should be possible to deep flatten data (async)', async () => {
-  let program = pipe(delay(0), flatten(), toArray())
+  let program = pipe(delay(0), flatten(), toArray)
 
   expect(await program([1, [2, [3, [[[4]], [5]]]]])).toEqual(Array.from(range(1, 5)))
   expect(await program([1, [2, [3, [[[4]], [5]]]]])).toEqual(Array.from(range(1, 5)))
 })
 
 it('should be possible to deep flatten data (Promise async)', async () => {
-  let program = pipe(flatten(), toArray())
+  let program = pipe(flatten(), toArray)
 
   expect(await program(Promise.resolve([1, [2, [3, [[[4]], [5]]]]]))).toEqual(
     Array.from(range(1, 5))

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -6,7 +6,7 @@ import { take } from './take'
 import { toArray } from './toArray'
 
 it('should be possible to create a stream using the generate function', () => {
-  let program = pipe(slice(0, 10), toArray())
+  let program = pipe(slice(0, 10), toArray)
 
   let i = 0
   expect(program(generate(() => i++))).toEqual(Array.from(range(0, 10)))
@@ -25,7 +25,7 @@ it('should be possible to create a fibonacci iterator', () => {
   }
 
   function fibonacci(x: number) {
-    return pipe(generate(createFibonacciGenerator()), take(x), toArray())()
+    return pipe(generate(createFibonacciGenerator()), take(x), toArray)()
   }
 
   expect(fibonacci(10)).toEqual([1, 1, 2, 3, 5, 8, 13, 21, 34, 55])

--- a/src/head.test.ts
+++ b/src/head.test.ts
@@ -4,49 +4,49 @@ import { head, first } from './head'
 import { delay } from './delay'
 
 it('should return the first element of the iterator', () => {
-  let program = pipe(range(20, 25), head())
+  let program = pipe(range(20, 25), head)
 
   expect(program()).toEqual(20)
 })
 
 it('should return the first element of the iterator (using an alias)', () => {
-  let program = pipe(range(20, 25), first())
+  let program = pipe(range(20, 25), first)
 
   expect(program()).toEqual(20)
 })
 
 it('should return undefined when there is no data', () => {
-  let program = pipe(first())
+  let program = pipe(first)
 
   expect(program()).toEqual(undefined)
 })
 
 it('should return undefined when there is an empty array', () => {
-  let program = pipe(first())
+  let program = pipe(first)
 
   expect(program([])).toEqual(undefined)
 })
 
 it('should return the first element of the iterator (async)', async () => {
-  let program = pipe(range(20, 25), delay(0), head())
+  let program = pipe(range(20, 25), delay(0), head)
 
   expect(await program()).toEqual(20)
 })
 
 it('should return the first element of the iterator (using an alias) (async)', async () => {
-  let program = pipe(range(20, 25), delay(0), first())
+  let program = pipe(range(20, 25), delay(0), first)
 
   expect(await program()).toEqual(20)
 })
 
 it('should return undefined when there is no data (async)', async () => {
-  let program = pipe(delay(0), first())
+  let program = pipe(delay(0), first)
 
   expect(await program()).toEqual(undefined)
 })
 
 it('should return undefined when there is an empty array (async)', async () => {
-  let program = pipe(delay(0), first())
+  let program = pipe(delay(0), first)
 
   expect(await program([])).toEqual(undefined)
 })

--- a/src/head.ts
+++ b/src/head.ts
@@ -1,8 +1,7 @@
 import { isAsyncIterable } from './utils/iterator'
 import { LazyIterable } from './shared-types'
 
-export function head<T>() {
-  return function headFn(data: LazyIterable<T>): T | undefined | Promise<T | undefined> {
+export function head<T>(data: LazyIterable<T>): T | undefined | Promise<T | undefined> {
     if (data == null) return
 
     if (isAsyncIterable(data) || data instanceof Promise) {
@@ -16,7 +15,6 @@ export function head<T>() {
 
     for (let datum of data) return datum
     return undefined
-  }
 }
 
 // Alias

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,7 +19,7 @@ it('should be possible to create a chain of actions and combine them in a nice s
     lazy.take(10),
 
     // To array
-    lazy.toArray()
+    lazy.toArray
   )
 
   expect(program(lazy.range(1_000, 1_000_000))).toEqual([

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -6,7 +6,7 @@ import { delay } from './delay'
 it('should be possible to map data from A to B', () => {
   let program = pipe(
     map((x: number) => x * 2), // Double
-    toArray()
+    toArray
   )
 
   expect(program([1, 2, 3])).toEqual([2, 4, 6])
@@ -16,7 +16,7 @@ it('should be possible to map data from A to B', () => {
 it('should return undefined when no stream is passing through it', () => {
   let program = pipe(
     map((x: number) => x * 2), // Double
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual(undefined)
@@ -27,7 +27,7 @@ it('should be possible to map data from A to B (async)', async () => {
   let program = pipe(
     delay(0),
     map((x: number) => x * 2), // Double
-    toArray()
+    toArray
   )
 
   expect(await program([1, 2, 3])).toEqual([2, 4, 6])
@@ -38,7 +38,7 @@ it('should be possible to map data from A to B (Promise async)', async () => {
   let program = pipe(
     delay(0),
     map((x: number) => x * 2), // Double
-    toArray()
+    toArray
   )
 
   expect(await program(Promise.resolve([1, 2, 3]))).toEqual([2, 4, 6])
@@ -48,7 +48,7 @@ it('should be possible to map data from A to B (Promise async)', async () => {
 it('should take the index as second argument', () => {
   let program = pipe(
     map((_x: number, i) => i),
-    toArray()
+    toArray
   )
 
   expect(program([1, 2, 3])).toEqual([0, 1, 2])

--- a/src/max.test.ts
+++ b/src/max.test.ts
@@ -4,13 +4,13 @@ import { max } from './max'
 import { delay } from './delay'
 
 it('should find the max value of the iterator', () => {
-  let program = pipe(range(5, 10), max())
+  let program = pipe(range(5, 10), max)
 
   expect(program()).toEqual(10)
 })
 
 it('should find the max value of the iterator (async)', async () => {
-  let program = pipe(range(5, 10), delay(0), max())
+  let program = pipe(range(5, 10), delay(0), max)
 
   expect(await program()).toEqual(10)
 })

--- a/src/max.ts
+++ b/src/max.ts
@@ -1,5 +1,6 @@
 import { reduce } from './reduce'
+import { LazyIterable } from './shared-types';
 
-export function max() {
-  return reduce((lhs, rhs) => Math.max(lhs, rhs), -Infinity)
+export function max(data: LazyIterable<number>) {
+  return reduce((lhs, rhs) => Math.max(lhs, rhs), -Infinity)(data)
 }

--- a/src/min.test.ts
+++ b/src/min.test.ts
@@ -4,13 +4,13 @@ import { min } from './min'
 import { delay } from './delay'
 
 it('should find the min value of the iterator', () => {
-  let program = pipe(range(5, 10), min())
+  let program = pipe(range(5, 10), min)
 
   expect(program()).toEqual(5)
 })
 
 it('should find the min value of the iterator (async)', async () => {
-  let program = pipe(range(5, 10), delay(0), min())
+  let program = pipe(range(5, 10), delay(0), min)
 
   expect(await program()).toEqual(5)
 })

--- a/src/min.ts
+++ b/src/min.ts
@@ -1,5 +1,6 @@
 import { reduce } from './reduce'
+import { LazyIterable } from './shared-types';
 
-export function min() {
-  return reduce((lhs, rhs) => Math.min(lhs, rhs), Infinity)
+export function min(data: LazyIterable<number>) {
+  return reduce((lhs, rhs) => Math.min(lhs, rhs), Infinity)(data)
 }

--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -8,7 +8,7 @@ it('should partition the data into 2 streams based on the predicate', () => {
   let program = pipe(
     range(1, 4),
     partition((x: number) => x % 2 !== 0),
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual([
@@ -20,7 +20,7 @@ it('should partition the data into 2 streams based on the predicate', () => {
 it('should return undefined when no stream is passing through it', () => {
   let program = pipe(
     partition((x: number) => x % 2 !== 0),
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual(undefined)
@@ -31,7 +31,7 @@ it('should partition the data into 2 streams based on the predicate (async)', as
     range(1, 4),
     delay(0),
     partition((x: number) => x % 2 !== 0),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([
@@ -44,7 +44,7 @@ it('should partition the data into 2 streams based on the predicate (Promise asy
   let program = pipe(
     Promise.resolve(range(1, 4)),
     partition((x: number) => x % 2 !== 0),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([
@@ -57,7 +57,7 @@ it('should take the index as second argument', async () => {
   let program = pipe(
     Promise.resolve(range(1, 4)),
     partition((_x: number, i) => i % 2 !== 0),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -15,7 +15,7 @@ it('should be possible to pipe multiple functions', () => {
 })
 
 it('should be possible to pass a generator as first argument', () => {
-  let program = pipe(generate(Math.random), take(10), toArray())
+  let program = pipe(generate(Math.random), take(10), toArray)
   let result = program()
   expect(result).toHaveLength(10)
 })

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -6,19 +6,19 @@ import { reverse } from './reverse'
 import { delay } from './delay'
 
 it('should be possible to reverse an iterator', () => {
-  let program = pipe(range(0, 1_000), reverse(), take(5), toArray())
+  let program = pipe(range(0, 1_000), reverse(), take(5), toArray)
 
   expect(program()).toEqual([1_000, 1_000 - 1, 1_000 - 2, 1_000 - 3, 1_000 - 4])
 })
 
 it('should be possible to reverse an iterator (async)', async () => {
-  let program = pipe(range(0, 1_000), delay(0), reverse(), take(5), toArray())
+  let program = pipe(range(0, 1_000), delay(0), reverse(), take(5), toArray)
 
   expect(await program()).toEqual([1_000, 1_000 - 1, 1_000 - 2, 1_000 - 3, 1_000 - 4])
 })
 
 it('should be possible to reverse an iterator (Promise async)', async () => {
-  let program = pipe(Promise.resolve(range(0, 1_000)), reverse(), take(5), toArray())
+  let program = pipe(Promise.resolve(range(0, 1_000)), reverse(), take(5), toArray)
 
   expect(await program()).toEqual([1_000, 1_000 - 1, 1_000 - 2, 1_000 - 3, 1_000 - 4])
 })

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -6,19 +6,19 @@ import { reverse } from './reverse'
 import { delay } from './delay'
 
 it('should be possible to reverse an iterator', () => {
-  let program = pipe(range(0, 1_000), reverse(), take(5), toArray)
+  let program = pipe(range(0, 1_000), reverse, take(5), toArray)
 
   expect(program()).toEqual([1_000, 1_000 - 1, 1_000 - 2, 1_000 - 3, 1_000 - 4])
 })
 
 it('should be possible to reverse an iterator (async)', async () => {
-  let program = pipe(range(0, 1_000), delay(0), reverse(), take(5), toArray)
+  let program = pipe(range(0, 1_000), delay(0), reverse, take(5), toArray)
 
   expect(await program()).toEqual([1_000, 1_000 - 1, 1_000 - 2, 1_000 - 3, 1_000 - 4])
 })
 
 it('should be possible to reverse an iterator (Promise async)', async () => {
-  let program = pipe(Promise.resolve(range(0, 1_000)), reverse(), take(5), toArray)
+  let program = pipe(Promise.resolve(range(0, 1_000)), reverse, take(5), toArray)
 
   expect(await program()).toEqual([1_000, 1_000 - 1, 1_000 - 2, 1_000 - 3, 1_000 - 4])
 })

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -8,8 +8,7 @@ import { LazyIterable } from './shared-types'
  * (to make it an array), then reverse the whole thing and then start
  * yielding again.
  */
-export function reverse<T>() {
-  return function reverseFn(data: LazyIterable<T>) {
+export function reverse<T>(data: LazyIterable<T>) {
     if (isAsyncIterable(data) || data instanceof Promise) {
       return {
         async *[Symbol.asyncIterator]() {
@@ -33,5 +32,4 @@ export function reverse<T>() {
         for (let datum of Array.from(data).reverse()) yield datum
       },
     }
-  }
 }

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -15,7 +15,7 @@ export function reverse<T>() {
         async *[Symbol.asyncIterator]() {
           let stream = data instanceof Promise ? await data : data
 
-          let program = pipe(toArray())
+          let program = pipe(toArray)
           let array = await program(stream)
 
           for await (let datum of array.reverse()) yield datum

--- a/src/skip.test.ts
+++ b/src/skip.test.ts
@@ -6,31 +6,31 @@ import { take } from './take'
 import { delay } from './delay'
 
 it('should skip x values', () => {
-  let program = pipe(skip(5), toArray())
+  let program = pipe(skip(5), toArray)
 
   expect(program(range(0, 10))).toEqual([5, 6, 7, 8, 9, 10])
 })
 
 it('should skip x values and take y values', () => {
-  let program = pipe(skip(5), take(3), toArray())
+  let program = pipe(skip(5), take(3), toArray)
 
   expect(program(range(0, 10))).toEqual([5, 6, 7])
 })
 
 it('should skip x values (async)', async () => {
-  let program = pipe(delay(0), skip(5), toArray())
+  let program = pipe(delay(0), skip(5), toArray)
 
   expect(await program(range(0, 10))).toEqual([5, 6, 7, 8, 9, 10])
 })
 
 it('should skip x values and take y values (async)', async () => {
-  let program = pipe(delay(0), skip(5), take(3), toArray())
+  let program = pipe(delay(0), skip(5), take(3), toArray)
 
   expect(await program(range(0, 10))).toEqual([5, 6, 7])
 })
 
 it('should skip x values and take y values (Promise async)', async () => {
-  let program = pipe(skip(5), take(3), toArray())
+  let program = pipe(skip(5), take(3), toArray)
 
   expect(await program(Promise.resolve(range(0, 10)))).toEqual([5, 6, 7])
 })

--- a/src/slice.test.ts
+++ b/src/slice.test.ts
@@ -8,7 +8,7 @@ it.each([
   [0, 10, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
   [4, 6, [4, 5, 6]],
 ])('should be possible to slice from %p until %p', (start, end, expected) => {
-  let program = pipe(slice(start, end), toArray())
+  let program = pipe(slice(start, end), toArray)
 
   expect(program(range(0, 1_000_000_000))).toEqual(expected)
   expect(program(range(0, 1_000_000_000))).toEqual(expected)
@@ -18,38 +18,38 @@ it.each([
   [0, 10, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
   [4, 6, [4, 5, 6]],
 ])('should be possible to slice from %p until %p (async)', async (start, end, expected) => {
-  let program = pipe(delay(0), slice(start, end), toArray())
+  let program = pipe(delay(0), slice(start, end), toArray)
 
   expect(await program(range(0, 1_000_000_000))).toEqual(expected)
   expect(await program(range(0, 1_000_000_000))).toEqual(expected)
 })
 
 it('should be possible to pass an array to slice', () => {
-  let program = pipe(slice(0, 1), toArray())
+  let program = pipe(slice(0, 1), toArray)
   expect(program([1, 2, 3, 4])).toEqual([1, 2])
 })
 
 it('should be possible to pass an iterator to slice', () => {
-  let program = pipe(slice(0, 1), toArray())
+  let program = pipe(slice(0, 1), toArray)
   expect(program(range(1, 4))).toEqual([1, 2])
 })
 
 it('should be possible to pass an array to slice (async)', async () => {
-  let program = pipe(delay(0), slice(0, 1), toArray())
+  let program = pipe(delay(0), slice(0, 1), toArray)
   expect(await program([1, 2, 3, 4])).toEqual([1, 2])
 })
 
 it('should be possible to pass an iterator to slice (async)', async () => {
-  let program = pipe(delay(0), slice(0, 1), toArray())
+  let program = pipe(delay(0), slice(0, 1), toArray)
   expect(await program(range(1, 4))).toEqual([1, 2])
 })
 
 it('should be possible to pass an array to slice (Promise async)', async () => {
-  let program = pipe(slice(0, 1), toArray())
+  let program = pipe(slice(0, 1), toArray)
   expect(await program(Promise.resolve([1, 2, 3, 4]))).toEqual([1, 2])
 })
 
 it('should be possible to pass an iterator to slice (Promise async)', async () => {
-  let program = pipe(slice(0, 1), toArray())
+  let program = pipe(slice(0, 1), toArray)
   expect(await program(Promise.resolve(range(1, 4)))).toEqual([1, 2])
 })

--- a/src/sum.test.ts
+++ b/src/sum.test.ts
@@ -4,42 +4,42 @@ import { range } from './range'
 import { delay } from './delay'
 
 it('should be possible to sum an array', () => {
-  let program = pipe(sum())
+  let program = pipe(sum)
 
   expect(program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(55)
   expect(program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(55)
 })
 
 it('should be possible to sum an iterator', () => {
-  let program = pipe(sum())
+  let program = pipe(sum)
 
   expect(program(range(0, 10))).toEqual(55)
   expect(program(range(0, 10))).toEqual(55)
 })
 
 it('should be possible to sum an array (async)', async () => {
-  let program = pipe(delay(0), sum())
+  let program = pipe(delay(0), sum)
 
   expect(await program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(55)
   expect(await program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(55)
 })
 
 it('should be possible to sum an iterator (async)', async () => {
-  let program = pipe(delay(0), sum())
+  let program = pipe(delay(0), sum)
 
   expect(await program(range(0, 10))).toEqual(55)
   expect(await program(range(0, 10))).toEqual(55)
 })
 
 it('should be possible to sum an array (Promise async)', async () => {
-  let program = pipe(sum())
+  let program = pipe(sum)
 
   expect(await program(Promise.resolve([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toEqual(55)
   expect(await program(Promise.resolve([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toEqual(55)
 })
 
 it('should be possible to sum an iterator (Promise async)', async () => {
-  let program = pipe(sum())
+  let program = pipe(sum)
 
   expect(await program(Promise.resolve(range(0, 10)))).toEqual(55)
   expect(await program(Promise.resolve(range(0, 10)))).toEqual(55)

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -1,5 +1,6 @@
 import { reduce } from './reduce'
+import { LazyIterable } from './shared-types';
 
-export function sum() {
-  return reduce((total, current) => total + current, 0)
+export function sum(data: LazyIterable<number>) {
+  return reduce((total, current) => total + current, 0)(data)
 }

--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -5,19 +5,19 @@ import { toArray } from './toArray'
 import { delay } from './delay'
 
 it('should take a only X values', () => {
-  let program = pipe(take(5), toArray())
+  let program = pipe(take(5), toArray)
 
   expect(program(range(0, 1_000))).toEqual([0, 1, 2, 3, 4])
 })
 
 it('should take a only X values (async)', async () => {
-  let program = pipe(delay(0), take(5), toArray())
+  let program = pipe(delay(0), take(5), toArray)
 
   expect(await program(range(0, 1_000))).toEqual([0, 1, 2, 3, 4])
 })
 
 it('should take a only X values (Promise async)', async () => {
-  let program = pipe(take(5), toArray())
+  let program = pipe(take(5), toArray)
 
   expect(await program(Promise.resolve(range(0, 1_000)))).toEqual([0, 1, 2, 3, 4])
 })

--- a/src/takeWhile.test.ts
+++ b/src/takeWhile.test.ts
@@ -7,7 +7,7 @@ import { delay } from './delay'
 it('should be possible to take values as long as they meet a certain condition', () => {
   let program = pipe(
     takeWhile((x: number) => x < 5),
-    toArray()
+    toArray
   )
 
   expect(program(range(0, 1_000))).toEqual([0, 1, 2, 3, 4])
@@ -17,7 +17,7 @@ it('should be possible to take values as long as they meet a certain condition (
   let program = pipe(
     delay(0),
     takeWhile((x: number) => x < 5),
-    toArray()
+    toArray
   )
 
   expect(await program(range(0, 1_000))).toEqual([0, 1, 2, 3, 4])
@@ -26,7 +26,7 @@ it('should be possible to take values as long as they meet a certain condition (
 it('should be possible to take values as long as they meet a certain condition (Promise async)', async () => {
   let program = pipe(
     takeWhile((x: number) => x < 5),
-    toArray()
+    toArray
   )
 
   expect(await program(Promise.resolve(range(0, 1_000)))).toEqual([0, 1, 2, 3, 4])
@@ -35,7 +35,7 @@ it('should be possible to take values as long as they meet a certain condition (
 it('should take the index as second argument', async () => {
   let program = pipe(
     takeWhile((_x: number, i) => i < 5),
-    toArray()
+    toArray
   )
 
   expect(await program(Promise.resolve(range(0, 1_000)))).toEqual([0, 1, 2, 3, 4])

--- a/src/tap.test.ts
+++ b/src/tap.test.ts
@@ -11,7 +11,7 @@ it('should be possible to tap into the current sequence', () => {
     tap(value => {
       fn(value)
     }),
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual([0, 1, 2, 3, 4, 5])
@@ -26,7 +26,7 @@ it('should be possible to tap into the current sequence (async)', async () => {
     tap(value => {
       fn(value)
     }),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([0, 1, 2, 3, 4, 5])
@@ -40,7 +40,7 @@ it('should be possible to tap into the current sequence (Promise async)', async 
     tap(value => {
       fn(value)
     }),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([0, 1, 2, 3, 4, 5])
@@ -54,7 +54,7 @@ it('should take the index as second argument', async () => {
     tap((_value, index) => {
       fn(index)
     }),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([0, 1, 2, 3, 4, 5])

--- a/src/toArray.test.ts
+++ b/src/toArray.test.ts
@@ -4,19 +4,19 @@ import { toArray } from './toArray'
 import { delay } from './delay'
 
 it('should convert an iterator to an array', () => {
-  let program = pipe(range(0, 10), toArray())
+  let program = pipe(range(0, 10), toArray)
 
   expect(program()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })
 
 it('should convert an iterator to an array (async)', async () => {
-  let program = pipe(range(0, 10), delay(0), toArray())
+  let program = pipe(range(0, 10), delay(0), toArray)
 
   expect(await program()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })
 
 it('should convert an iterator to an array (Promise async)', async () => {
-  let program = pipe(Promise.resolve(range(0, 10)), toArray())
+  let program = pipe(Promise.resolve(range(0, 10)), toArray)
 
   expect(await program()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })

--- a/src/toArray.ts
+++ b/src/toArray.ts
@@ -1,11 +1,9 @@
 import { reduce } from './reduce'
 import { LazyIterable } from './shared-types'
 
-export function toArray<T>() {
-  return (data: LazyIterable<T>) => {
+export function toArray<T>(data: LazyIterable<T>) {
     return reduce<T[], T>((acc, current) => {
       acc.push(current)
       return acc
     }, [])(data)
-  }
 }

--- a/src/unique.test.ts
+++ b/src/unique.test.ts
@@ -13,7 +13,7 @@ it('should be possible to create a unique stream', () => {
   let program = pipe(
     map((x: number) => snap(5, x)),
     unique(),
-    toArray()
+    toArray
   )
 
   expect(program(range(0, 10))).toEqual([0, 5, 10])
@@ -24,14 +24,14 @@ it('should be possible to create a unique stream (async)', async () => {
     delay(0),
     map((x: number) => snap(5, x)),
     unique(),
-    toArray()
+    toArray
   )
 
   expect(await program(range(0, 10))).toEqual([0, 5, 10])
 })
 
 it('should be possible to create a unique stream (Promise async)', async () => {
-  let program = pipe(unique(), toArray())
+  let program = pipe(unique(), toArray)
 
   expect(await program(Promise.resolve([0, 0, 5, 5, 5, 10, 10]))).toEqual([0, 5, 10])
 })

--- a/src/unique.test.ts
+++ b/src/unique.test.ts
@@ -12,7 +12,7 @@ function snap(multitude: number, value: number) {
 it('should be possible to create a unique stream', () => {
   let program = pipe(
     map((x: number) => snap(5, x)),
-    unique(),
+    unique,
     toArray
   )
 
@@ -23,7 +23,7 @@ it('should be possible to create a unique stream (async)', async () => {
   let program = pipe(
     delay(0),
     map((x: number) => snap(5, x)),
-    unique(),
+    unique,
     toArray
   )
 
@@ -31,7 +31,7 @@ it('should be possible to create a unique stream (async)', async () => {
 })
 
 it('should be possible to create a unique stream (Promise async)', async () => {
-  let program = pipe(unique(), toArray)
+  let program = pipe(unique, toArray)
 
   expect(await program(Promise.resolve([0, 0, 5, 5, 5, 10, 10]))).toEqual([0, 5, 10])
 })

--- a/src/unique.ts
+++ b/src/unique.ts
@@ -1,8 +1,7 @@
 import { isAsyncIterable } from './utils/iterator'
 import { LazyIterable } from './shared-types'
 
-export function unique<T>() {
-  return function uniqueFn(data: LazyIterable<T>) {
+export function unique<T>(data: LazyIterable<T>) {
     let seen = new Set<T>([])
 
     if (isAsyncIterable(data) || data instanceof Promise) {
@@ -29,6 +28,5 @@ export function unique<T>() {
           }
         }
       },
-    }
   }
 }

--- a/src/where.test.ts
+++ b/src/where.test.ts
@@ -10,14 +10,14 @@ it('should be possible to get the items containing certain properties', () => {
     range(0, 10),
     map((x: number) => ({ x, y: x + 1 })),
     where({ x: 3, y: 4 }),
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual([{ x: 3, y: 4 }])
 })
 
 it('should not crash on values that it does not understand', () => {
-  let program = pipe(where({ include: true }), toArray())
+  let program = pipe(where({ include: true }), toArray)
 
   expect(
     program([
@@ -37,7 +37,7 @@ it('should be possible to get the items containing certain magic properties like
     range(0, 3),
     map((x: number) => [x, x]),
     where({ length: 2 }),
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual([
@@ -54,7 +54,7 @@ it('should be possible to get the items containing certain properties (async)', 
     delay(0),
     map((x: number) => ({ x, y: x + 1 })),
     where({ x: 3, y: 4 }),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([{ x: 3, y: 4 }])
@@ -66,7 +66,7 @@ it('should be possible to get the items containing certain magic properties like
     delay(0),
     map((x: number) => [x, x]),
     where({ length: 2 }),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([
@@ -82,7 +82,7 @@ it('should be possible to get the items containing certain properties (Promise a
     Promise.resolve(range(0, 10)),
     map((x: number) => ({ x, y: x + 1 })),
     where({ x: 3, y: 4 }),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([{ x: 3, y: 4 }])
@@ -93,7 +93,7 @@ it('should be possible to get the items containing certain magic properties like
     Promise.resolve(range(0, 3)),
     map((x: number) => [x, x]),
     where({ length: 2 }),
-    toArray()
+    toArray
   )
 
   expect(await program()).toEqual([

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -11,7 +11,7 @@ it('should be possible to zip data together', () => {
       [0, 1, 2, 3],
       ['A', 'B', 'C', 'D'],
     ],
-    zip(),
+    zip,
     toArray
   )
 
@@ -24,7 +24,7 @@ it('should be possible to zip data together', () => {
 })
 
 it('should be possible to zip data together from a generator', () => {
-  let program = pipe(range(0, 1_000), chunk(4), take(5), zip(), take(5), toArray)
+  let program = pipe(range(0, 1_000), chunk(4), take(5), zip, take(5), toArray)
 
   expect(program()).toEqual([
     [0, 4, 8, 12, 16],
@@ -42,7 +42,7 @@ it('should drop non matchable values', () => {
       [0, 1, 2, 3],
       ['A', 'B', 'C'],
     ],
-    zip(),
+    zip,
     toArray
   )
 
@@ -59,7 +59,7 @@ it('should be chainable with a take so that only a few items are zipped', () => 
       [0, 1, 2, 3],
       ['A', 'B', 'C'],
     ],
-    zip(),
+    zip,
     take(2),
     toArray
   )
@@ -71,7 +71,7 @@ it('should be chainable with a take so that only a few items are zipped', () => 
 })
 
 it('should zip multiple iterators together', () => {
-  let program = pipe([range(0, 999), range(999, 0)], zip(), take(5), toArray)
+  let program = pipe([range(0, 999), range(999, 0)], zip, take(5), toArray)
 
   expect(program()).toEqual([
     [0, 999],

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -12,7 +12,7 @@ it('should be possible to zip data together', () => {
       ['A', 'B', 'C', 'D'],
     ],
     zip(),
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual([
@@ -24,7 +24,7 @@ it('should be possible to zip data together', () => {
 })
 
 it('should be possible to zip data together from a generator', () => {
-  let program = pipe(range(0, 1_000), chunk(4), take(5), zip(), take(5), toArray())
+  let program = pipe(range(0, 1_000), chunk(4), take(5), zip(), take(5), toArray)
 
   expect(program()).toEqual([
     [0, 4, 8, 12, 16],
@@ -43,7 +43,7 @@ it('should drop non matchable values', () => {
       ['A', 'B', 'C'],
     ],
     zip(),
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual([
@@ -61,7 +61,7 @@ it('should be chainable with a take so that only a few items are zipped', () => 
     ],
     zip(),
     take(2),
-    toArray()
+    toArray
   )
 
   expect(program()).toEqual([
@@ -71,7 +71,7 @@ it('should be chainable with a take so that only a few items are zipped', () => 
 })
 
 it('should zip multiple iterators together', () => {
-  let program = pipe([range(0, 999), range(999, 0)], zip(), take(5), toArray())
+  let program = pipe([range(0, 999), range(999, 0)], zip(), take(5), toArray)
 
   expect(program()).toEqual([
     [0, 999],

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,17 +1,15 @@
-export function zip<T>() {
-  return function* zipFn(data: Iterable<Iterable<T>>) {
-    // Map each item of `data` to an iterator
-    let iterators = Array.from(data).map(datum => datum[Symbol.iterator]())
+export function *zip<T>(data: Iterable<Iterable<T>>) {
+  // Map each item of `data` to an iterator
+  let iterators = Array.from(data).map(datum => datum[Symbol.iterator]())
 
-    while (true) {
-      // Take the next value of each iterator
-      let values = iterators.map(datum => datum.next())
+  while (true) {
+    // Take the next value of each iterator
+    let values = iterators.map(datum => datum.next())
 
-      // Stop once some values are done
-      if (values.some(value => value.done)) return
+    // Stop once some values are done
+    if (values.some(value => value.done)) return
 
-      // Yield the actual values zipped together
-      yield values.map(value => value.value)
-    }
+    // Yield the actual values zipped together
+    yield values.map(value => value.value)
   }
 }


### PR DESCRIPTION
Many functions do not take parameters, so they do not need to be higher-order functions.
For the sake of readability and coherence with other FP libraries, I find it better that we just call `toArray` in our code, instead of `toArray()`.

Functions that were modified : 

toArray
compact
reverse
zip
unique
sum
min
max
head
average

Test = OK
Readme = OK