### PR TITLE
add, test, and document `includes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ program(range(0, 1000000))
     - [`find`](#find)
     - [`findIndex`](#findindex)
     - [`flatMap`](#flatMap)
+    - [`includes`](#includes)
     - [`join`](#join)
     - [`map`](#map)
     - [`reduce`](#reduce)
@@ -283,6 +284,36 @@ let program = pipe(
 
 program([1, 2, 3])
 // [ 2, 4, 4, 8, 6, 12 ]
+```
+
+#### `includes`
+
+[Table of contents](#table-of-contents)
+
+Check if a value is included in an array or iterator.
+
+```js
+import { pipe, includes } from 'lazy-collections'
+
+let program = pipe(includes(1))
+
+program([1, 2, 3, 4])
+
+// true
+```
+
+Values are compared with strict equality.
+
+Optionally, you can start searching from a positive index:
+
+```js
+import { pipe, includes } from 'lazy-collections'
+
+let program = pipe(includes(1, 1))
+
+program([1, 2, 3, 4])
+
+// false
 ```
 
 #### `join`

--- a/src/includes.test.ts
+++ b/src/includes.test.ts
@@ -1,0 +1,126 @@
+import { pipe } from './pipe'
+import { range } from './range'
+import { includes } from './includes'
+import { map } from './map'
+import { delay } from './delay'
+
+it('should return true when the search element is found', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+
+  expect(program(range(0, 25))).toBe(true)
+  expect(program(range(0, 25))).toBe(true)
+})
+
+it('should return false when the search element is not found', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+
+  expect(program(range(0, 24))).toBe(false)
+  expect(program(range(0, 24))).toBe(false)
+})
+
+it('should return true when the search element is found, starting at a given index', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z', 1)
+  )
+
+  expect(program(range(0, 25))).toBe(true)
+  expect(program(range(0, 25))).toBe(true)
+})
+
+it('should return false when the search element is not found, starting at a given index', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('A', 1)
+  )
+
+  expect(program(range(0, 25))).toBe(false)
+  expect(program(range(0, 25))).toBe(false)
+})
+
+it('should return true when the search element is found (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+  
+  expect(await program(range(0, 25))).toBe(true)
+  expect(await program(range(0, 25))).toBe(true)
+})
+
+it('should return false when the search element is not found (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+
+  expect(await program(range(0, 24))).toBe(false)
+  expect(await program(range(0, 24))).toBe(false)
+})
+
+it('should return true when the search element is found, starting at a given index (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z', 1)
+  )
+
+  expect(await program(range(0, 25))).toBe(true)
+  expect(await program(range(0, 25))).toBe(true)
+})
+
+it('should return false when the search element is not found, starting at a given index (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('A', 1)
+  )
+
+  expect(await program(range(0, 25))).toBe(false)
+  expect(await program(range(0, 25))).toBe(false)
+})
+
+it('should return true when the search element is found (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(true)
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(true)
+})
+
+it('should return false when the search element is not found (Promise async)', async () => {
+  let program = pipe(includes('Z'))
+
+  expect(await program(Promise.resolve(range(0, 24)))).toBe(false)
+  expect(await program(Promise.resolve(range(0, 24)))).toBe(false)
+})
+
+it('should return true when the search element is found, starting at a given index (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z', 1)
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(true)
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(true)
+})
+
+it('should return false when the search element is not found, starting at a given index (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('A', 1)
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(false)
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(false)
+})

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -1,0 +1,23 @@
+import { findIndex } from './findIndex'
+import { isAsyncIterable } from './utils/iterator'
+import { LazyIterable } from './shared-types'
+
+export function includes(searchElement: any, fromIndex?: number) {
+  let resolvedFromIndex = (fromIndex && fromIndex >= 0) ? fromIndex : 0
+  let predicate: Parameters<typeof findIndex>[0] = (element, index) => {
+    if (index < resolvedFromIndex) return false
+    return element === searchElement
+  }
+
+  return function includesFn(data: LazyIterable<any>) {
+    if (isAsyncIterable(data) || data instanceof Promise) {
+      return (async () => {
+        let index = await findIndex(predicate)(data)
+        return index !== -1
+      })()
+    }
+
+    let index = findIndex(predicate)(data)
+    return index !== -1
+  }
+}


### PR DESCRIPTION
Matches functionality of `Array.prototype.includes`, except that it doesn't support a negative `fromIndex`, to avoid exhausting the full iterator. Followed the lead of `slice` when making that decision.