### PR TITLE
add, test, and document `at`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ program(range(0, 1000000))
     - [`compose`](#compose)
     - [`pipe`](#pipe)
   - [Known array functions](#known-array-functions)
+    - [`at`](#at)
     - [`concat`](#concat)
     - [`every`](#every)
     - [`filter`](#filter)
@@ -188,6 +189,36 @@ program()
 ```
 
 ### Known array functions
+
+#### `at`
+
+[Table of contents](#table-of-contents)
+
+Returns the value at the given index.
+
+```js
+import { pipe, at } from 'lazy-collections'
+
+let program = pipe(at(2))
+
+program([1, 2, 3, 4])
+
+// 3
+```
+
+You can also pass a negative index to `at` to count back from the end of the array or iterator.
+
+> **Warning**: Performance warning, it has to exhaust the full iterator before it can count backward!
+
+```js
+import { pipe, at } from 'lazy-collections'
+
+let program = pipe(at(-2))
+
+program([1, 2, 3, 4])
+
+// 3
+```
 
 #### `concat`
 

--- a/src/at.test.ts
+++ b/src/at.test.ts
@@ -1,0 +1,95 @@
+import { pipe } from './pipe'
+import { range } from './range'
+import { at } from './at'
+import { map } from './map'
+import { delay } from './delay'
+
+it('should return the element at the given index', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+
+  expect(program(range(0, 25))).toBe('Z')
+  expect(program(range(0, 25))).toBe('Z')
+})
+
+it('should return undefined when the given index is out of bounds', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+
+  expect(program(range(0, 24))).toBeUndefined()
+  expect(program(range(0, 24))).toBeUndefined()
+})
+
+it('should return the element at the given index (negative)', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(-1)
+  )
+
+  expect(program(range(0, 25))).toBe('Z')
+  expect(program(range(0, 25))).toBe('Z')
+})
+
+it('should return the element at the given index (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+  
+  expect(await program(range(0, 25))).toBe('Z')
+  expect(await program(range(0, 25))).toBe('Z')
+})
+
+it('should return undefined when the given index is out of bounds (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+
+  expect(await program(range(0, 24))).toBeUndefined()
+  expect(await program(range(0, 24))).toBeUndefined()
+})
+
+it('should return the element at the given index (negative) (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(-1)
+  )
+
+  expect(await program(range(0, 25))).toBe('Z')
+  expect(await program(range(0, 25))).toBe('Z')
+})
+
+it('should return the element at the given index (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe('Z')
+  expect(await program(Promise.resolve(range(0, 25)))).toBe('Z')
+})
+
+it('should return undefined when the given index is out of bounds (Promise async)', async () => {
+  let program = pipe(at(25))
+
+  expect(await program(Promise.resolve(range(0, 24)))).toBeUndefined()
+  expect(await program(Promise.resolve(range(0, 24)))).toBeUndefined()
+})
+
+it('should return the element at the given index (negative) (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(-1)
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe('Z')
+  expect(await program(Promise.resolve(range(0, 25)))).toBe('Z')
+})

--- a/src/at.ts
+++ b/src/at.ts
@@ -1,0 +1,33 @@
+import { find } from './find'
+import { isAsyncIterable } from './utils/iterator'
+import { pipe } from './pipe'
+import { toArray } from './toArray'
+import { LazyIterable } from './shared-types'
+
+export function at<T>(index: number) {
+  if (index >= 0) {
+    return function atFn(data: LazyIterable<T>) {
+      return find((_, i) => (i === index))(data)
+    }
+  }
+  
+  /**
+   * To support counting back with a negative index, the whole iteraror has to be
+   * converted to an array. Then, `Array.prototype.at` can be used. This is slow,
+   * but it helps deliver a consistent UX.
+   */
+  return function atFn(data: LazyIterable<T>) {
+    if (isAsyncIterable(data) || data instanceof Promise) {
+      return (async () => {
+        let stream = data instanceof Promise ? await data : data
+
+        let program = pipe(toArray())
+        let array = await program(stream)
+
+        return array.at(index)
+      })()
+    }
+
+    return Array.from(data).at(index)
+  }
+}


### PR DESCRIPTION
For `at`, I decided to support both positive and negative indices, since negative indices are such a popular feature of `Array.prototype.at`.

When the index is positive, it uses `find` under the hood for optimal performance. When the index is negative, it basically works the same way as `reverse`—convert the whole iterator to an array, and fall back to `Array.prototype.at` under the hood. 