### PR TITLE
add, test, and document length

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ program(range(0, 1000000))
     - [`takeWhile`](#takewhile)
     - [`tap`](#tap)
     - [`toArray`](#toarray)
+    - [`toLength`](#tolength)
     - [`toSet`](#toset)
     - [`unique`](#unique)
     - [`wait`](#wait)
@@ -388,6 +389,26 @@ let program = pipe(join(' '))
 
 program(['foo', 'bar', 'baz'])
 // 'foo bar baz'
+```
+
+#### `toLength`
+
+[Table of contents](#table-of-contents)
+
+> **Warning**: Performance warning, it has to exhaust the full iterator before it can calculate length!
+
+Get the length of an array or iterator.
+
+```js
+import { pipe, toLength, filter } from 'lazy-collections'
+
+let program = pipe(
+  filter((x) => x % 2 === 0),
+  toLength()
+)
+
+program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+// 5
 ```
 
 #### `map`

--- a/src/toLength.test.ts
+++ b/src/toLength.test.ts
@@ -1,0 +1,32 @@
+import { pipe } from './pipe'
+import { range } from './range'
+import { toLength } from './toLength'
+import { delay } from './delay'
+
+it('should return the length of the iterable', () => {
+  let program = pipe(
+    toLength()
+  )
+
+  expect(program(range(0, 25))).toBe(26)
+  expect(program(range(0, 25))).toBe(26)
+})
+
+it('should return the length of the iterable (async)', async () => {
+  let program = pipe(
+    delay(0),
+    toLength()
+  )
+  
+  expect(await program(range(0, 25))).toBe(26)
+  expect(await program(range(0, 25))).toBe(26)
+})
+
+it('should return the length of the iterable (Promise async)', async () => {
+  let program = pipe(
+    toLength()
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(26)
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(26)
+})

--- a/src/toLength.ts
+++ b/src/toLength.ts
@@ -1,0 +1,21 @@
+import { isAsyncIterable } from './utils/iterator'
+import { pipe } from './pipe'
+import { toArray } from './toArray'
+import { LazyIterable } from './shared-types'
+
+export function toLength() {
+  return function toLengthFn(data: LazyIterable<any>) {
+    if (isAsyncIterable(data) || data instanceof Promise) {
+      return (async () => {
+        let stream = data instanceof Promise ? await data : data
+
+        let program = pipe(toArray())
+        let array = await program(stream)
+
+        return array.length
+      })()
+    }
+
+    return Array.from(data).length
+  }
+}


### PR DESCRIPTION
Iterable length can easily be calculated by converting to an array:

```
const program = pipe(
  ...,
  toArray()
)

const length = program(...).length
```

The `toLength` function does the exact same thing (converts to array and accesses `.length`), but it lets you nicely co-locate that final transformation in the same pipeline, instead of splitting up the code unnecessarily.

```
const program = pipe(
  ...,
  toLength()
)

const length = program(...)
```