### PR TITLE
Add `includes` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Added
+
+- Add `includes` feature ([#24](https://github.com/RobinMalfait/lazy-collections/pull/24), [#29](https://github.com/RobinMalfait/lazy-collections/pull/29))
 
 ## [0.10.0] - 2022-08-27
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ program([1, 2, 3, 4])
 // true
 ```
 
-Values are compared with strict equality.
+Values are compared using `Object.is`.
 
 Optionally, you can start searching from a positive index:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ program(range(0, 1000000))
     - [`find`](#find)
     - [`findIndex`](#findindex)
     - [`flatMap`](#flatMap)
+    - [`includes`](#includes)
     - [`join`](#join)
     - [`map`](#map)
     - [`reduce`](#reduce)
@@ -285,6 +286,36 @@ let program = pipe(
 
 program([1, 2, 3])
 // [ 2, 4, 4, 8, 6, 12 ]
+```
+
+#### `includes`
+
+[Table of contents](#table-of-contents)
+
+Check if a value is included in an array or iterator.
+
+```js
+import { pipe, includes } from 'lazy-collections'
+
+let program = pipe(includes(1))
+
+program([1, 2, 3, 4])
+
+// true
+```
+
+Values are compared with strict equality.
+
+Optionally, you can start searching from a positive index:
+
+```js
+import { pipe, includes } from 'lazy-collections'
+
+let program = pipe(includes(1, 1))
+
+program([1, 2, 3, 4])
+
+// false
 ```
 
 #### `join`

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ program([1, 2, 3, 4])
 // true
 ```
 
-Values are compared using `Object.is`.
+Each value is compared using `Object.is`. This will guarantee that edge cases with `NaN` also work the same as `Array.prototype.includes`.
 
 Optionally, you can start searching from a positive index:
 

--- a/src/includes.test.ts
+++ b/src/includes.test.ts
@@ -14,6 +14,13 @@ it('should return true when the search element is found', () => {
   expect(program(range(0, 25))).toBe(true)
 })
 
+it('should return true when the search element is found and the search element is an edge case (NaN)', () => {
+  let program = pipe(includes(NaN))
+
+  expect(program([1, 2, 3, NaN])).toBe(true)
+  expect(program([1, 2, 3, NaN])).toBe(true)
+})
+
 it('should return false when the search element is not found', () => {
   let program = pipe(
     map((x: number) => String.fromCharCode(x + 65)),

--- a/src/includes.test.ts
+++ b/src/includes.test.ts
@@ -1,0 +1,126 @@
+import { pipe } from './pipe'
+import { range } from './range'
+import { includes } from './includes'
+import { map } from './map'
+import { delay } from './delay'
+
+it('should return true when the search element is found', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+
+  expect(program(range(0, 25))).toBe(true)
+  expect(program(range(0, 25))).toBe(true)
+})
+
+it('should return false when the search element is not found', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+
+  expect(program(range(0, 24))).toBe(false)
+  expect(program(range(0, 24))).toBe(false)
+})
+
+it('should return true when the search element is found, starting at a given index', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z', 1)
+  )
+
+  expect(program(range(0, 25))).toBe(true)
+  expect(program(range(0, 25))).toBe(true)
+})
+
+it('should return false when the search element is not found, starting at a given index', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('A', 1)
+  )
+
+  expect(program(range(0, 25))).toBe(false)
+  expect(program(range(0, 25))).toBe(false)
+})
+
+it('should return true when the search element is found (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+  
+  expect(await program(range(0, 25))).toBe(true)
+  expect(await program(range(0, 25))).toBe(true)
+})
+
+it('should return false when the search element is not found (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+
+  expect(await program(range(0, 24))).toBe(false)
+  expect(await program(range(0, 24))).toBe(false)
+})
+
+it('should return true when the search element is found, starting at a given index (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z', 1)
+  )
+
+  expect(await program(range(0, 25))).toBe(true)
+  expect(await program(range(0, 25))).toBe(true)
+})
+
+it('should return false when the search element is not found, starting at a given index (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('A', 1)
+  )
+
+  expect(await program(range(0, 25))).toBe(false)
+  expect(await program(range(0, 25))).toBe(false)
+})
+
+it('should return true when the search element is found (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z')
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(true)
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(true)
+})
+
+it('should return false when the search element is not found (Promise async)', async () => {
+  let program = pipe(includes('Z'))
+
+  expect(await program(Promise.resolve(range(0, 24)))).toBe(false)
+  expect(await program(Promise.resolve(range(0, 24)))).toBe(false)
+})
+
+it('should return true when the search element is found, starting at a given index (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('Z', 1)
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(true)
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(true)
+})
+
+it('should return false when the search element is not found, starting at a given index (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    includes('A', 1)
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(false)
+  expect(await program(Promise.resolve(range(0, 25)))).toBe(false)
+})

--- a/src/includes.test.ts
+++ b/src/includes.test.ts
@@ -50,7 +50,7 @@ it('should return true when the search element is found (async)', async () => {
     map((x: number) => String.fromCharCode(x + 65)),
     includes('Z')
   )
-  
+
   expect(await program(range(0, 25))).toBe(true)
   expect(await program(range(0, 25))).toBe(true)
 })

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -2,14 +2,14 @@ import { findIndex } from './findIndex'
 import { isAsyncIterable } from './utils/iterator'
 import { LazyIterable } from './shared-types'
 
-export function includes(searchElement: any, fromIndex?: number) {
+export function includes<T>(searchElement: T, fromIndex?: number) {
   let resolvedFromIndex = fromIndex && fromIndex >= 0 ? fromIndex : 0
-  let predicate: Parameters<typeof findIndex>[0] = (element, index) => {
+  function predicate(element: T, index: number) {
     if (index < resolvedFromIndex) return false
     return Object.is(element, searchElement)
   }
 
-  return function includesFn(data: LazyIterable<any>) {
+  return function includesFn(data: LazyIterable<T>) {
     if (isAsyncIterable(data) || data instanceof Promise) {
       return (async () => {
         let index = await findIndex(predicate)(data)

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -2,10 +2,9 @@ import { findIndex } from './findIndex'
 import { isAsyncIterable } from './utils/iterator'
 import { LazyIterable } from './shared-types'
 
-export function includes<T>(searchElement: T, fromIndex?: number) {
-  let resolvedFromIndex = fromIndex && fromIndex >= 0 ? fromIndex : 0
+export function includes<T>(searchElement: T, fromIndex = 0) {
   function predicate(element: T, index: number) {
-    if (index < resolvedFromIndex) return false
+    if (index < fromIndex) return false
     return Object.is(element, searchElement)
   }
 

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -1,0 +1,23 @@
+import { findIndex } from './findIndex'
+import { isAsyncIterable } from './utils/iterator'
+import { LazyIterable } from './shared-types'
+
+export function includes(searchElement: any, fromIndex?: number) {
+  let resolvedFromIndex = (fromIndex && fromIndex >= 0) ? fromIndex : 0
+  let predicate: Parameters<typeof findIndex>[0] = (element, index) => {
+    if (index < resolvedFromIndex) return false
+    return element === searchElement
+  }
+
+  return function includesFn(data: LazyIterable<any>) {
+    if (isAsyncIterable(data) || data instanceof Promise) {
+      return (async () => {
+        let index = await findIndex(predicate)(data)
+        return index !== -1
+      })()
+    }
+
+    let index = findIndex(predicate)(data)
+    return index !== -1
+  }
+}

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -6,7 +6,7 @@ export function includes(searchElement: any, fromIndex?: number) {
   let resolvedFromIndex = fromIndex && fromIndex >= 0 ? fromIndex : 0
   let predicate: Parameters<typeof findIndex>[0] = (element, index) => {
     if (index < resolvedFromIndex) return false
-    return element === searchElement
+    return Object.is(element, searchElement)
   }
 
   return function includesFn(data: LazyIterable<any>) {

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -3,7 +3,7 @@ import { isAsyncIterable } from './utils/iterator'
 import { LazyIterable } from './shared-types'
 
 export function includes(searchElement: any, fromIndex?: number) {
-  let resolvedFromIndex = (fromIndex && fromIndex >= 0) ? fromIndex : 0
+  let resolvedFromIndex = fromIndex && fromIndex >= 0 ? fromIndex : 0
   let predicate: Parameters<typeof findIndex>[0] = (element, index) => {
     if (index < resolvedFromIndex) return false
     return element === searchElement


### PR DESCRIPTION
This PR adds a new `includes` feature as a continuation of the existing PR #24.

This allows you to check if a certain value is seen in the data. Once it is, it will return early and result in a boolean.

```js
import { pipe, includes } from 'lazy-collections'

let program = pipe(includes(1))

program([1, 2, 3, 4])

// true
```

Each value is compared using `Object.is`. This will guarantee that edge cases with `NaN` also work the same as `Array.prototype.includes`.

Optionally, you can start searching from a positive index:

```js
import { pipe, includes } from 'lazy-collections'

let program = pipe(includes(1, 1))

program([1, 2, 3, 4])

// false
```

Closes: #24
Thanks, @AlexVipond!
