### PR TITLE
Add `at` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `includes` feature ([#24](https://github.com/RobinMalfait/lazy-collections/pull/24), [#29](https://github.com/RobinMalfait/lazy-collections/pull/29))
+- Add `at` feature ([#25](https://github.com/RobinMalfait/lazy-collections/pull/25), [#30](https://github.com/RobinMalfait/lazy-collections/pull/30))
 
 ## [0.10.0] - 2022-08-27
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ program([1, 2, 3, 4])
 
 You can also pass a negative index to `at` to count back from the end of the array or iterator.
 
-> **Warning**: Performance warning, it has to exhaust the full iterator before it can count backwards!
+> **Warning**: Performance may be degraded because it has to exhaust the full iterator before it can count backwards!
 
 ```js
 import { pipe, at } from 'lazy-collections'
@@ -422,7 +422,7 @@ program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
 #### `reverse`
 
-> **Warning**: Performance warning, it has to exhaust the full iterator before it can reverse it!
+> **Warning**: Performance may be degraded because it has to exhaust the full iterator before it can reverse it!
 
 [Table of contents](#table-of-contents)
 
@@ -454,7 +454,7 @@ program([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
 #### `sort`
 
-> **Warning**: Performance warning, it has to exhaust the full iterator before it can sort it!
+> **Warning**: Performance may be degraded because it has to exhaust the full iterator before it can sort it!
 
 [Table of contents](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ program(range(0, 1000000))
     - [`compose`](#compose)
     - [`pipe`](#pipe)
   - [Known array functions](#known-array-functions)
+    - [`at`](#at)
     - [`concat`](#concat)
     - [`every`](#every)
     - [`filter`](#filter)
@@ -191,6 +192,36 @@ program()
 ```
 
 ### Known array functions
+
+#### `at`
+
+[Table of contents](#table-of-contents)
+
+Returns the value at the given index.
+
+```js
+import { pipe, at } from 'lazy-collections'
+
+let program = pipe(at(2))
+
+program([1, 2, 3, 4])
+
+// 3
+```
+
+You can also pass a negative index to `at` to count back from the end of the array or iterator.
+
+> **Warning**: Performance warning, it has to exhaust the full iterator before it can count backward!
+
+```js
+import { pipe, at } from 'lazy-collections'
+
+let program = pipe(at(-2))
+
+program([1, 2, 3, 4])
+
+// 3
+```
 
 #### `concat`
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ program([1, 2, 3, 4])
 
 You can also pass a negative index to `at` to count back from the end of the array or iterator.
 
-> **Warning**: Performance warning, it has to exhaust the full iterator before it can count backward!
+> **Warning**: Performance warning, it has to exhaust the full iterator before it can count backwards!
 
 ```js
 import { pipe, at } from 'lazy-collections'
@@ -221,6 +221,18 @@ let program = pipe(at(-2))
 program([1, 2, 3, 4])
 
 // 3
+```
+
+If a value can not be found at the given index, then `undefined` will be returned.
+
+```js
+import { pipe, at } from 'lazy-collections'
+
+let program = pipe(at(12))
+
+program([1, 2, 3, 4])
+
+// undefined
 ```
 
 #### `concat`

--- a/src/at.test.ts
+++ b/src/at.test.ts
@@ -14,6 +14,16 @@ it('should return the element at the given index', () => {
   expect(program(range(0, 25))).toBe('Z')
 })
 
+it('should return undefined if the index does not exist', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(30)
+  )
+
+  expect(program(range(0, 25))).toBe(undefined)
+  expect(program(range(0, 25))).toBe(undefined)
+})
+
 it('should return undefined when the given index is out of bounds', () => {
   let program = pipe(
     map((x: number) => String.fromCharCode(x + 65)),

--- a/src/at.test.ts
+++ b/src/at.test.ts
@@ -1,0 +1,95 @@
+import { pipe } from './pipe'
+import { range } from './range'
+import { at } from './at'
+import { map } from './map'
+import { delay } from './delay'
+
+it('should return the element at the given index', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+
+  expect(program(range(0, 25))).toBe('Z')
+  expect(program(range(0, 25))).toBe('Z')
+})
+
+it('should return undefined when the given index is out of bounds', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+
+  expect(program(range(0, 24))).toBeUndefined()
+  expect(program(range(0, 24))).toBeUndefined()
+})
+
+it('should return the element at the given index (negative)', () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(-1)
+  )
+
+  expect(program(range(0, 25))).toBe('Z')
+  expect(program(range(0, 25))).toBe('Z')
+})
+
+it('should return the element at the given index (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+  
+  expect(await program(range(0, 25))).toBe('Z')
+  expect(await program(range(0, 25))).toBe('Z')
+})
+
+it('should return undefined when the given index is out of bounds (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+
+  expect(await program(range(0, 24))).toBeUndefined()
+  expect(await program(range(0, 24))).toBeUndefined()
+})
+
+it('should return the element at the given index (negative) (async)', async () => {
+  let program = pipe(
+    delay(0),
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(-1)
+  )
+
+  expect(await program(range(0, 25))).toBe('Z')
+  expect(await program(range(0, 25))).toBe('Z')
+})
+
+it('should return the element at the given index (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(25)
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe('Z')
+  expect(await program(Promise.resolve(range(0, 25)))).toBe('Z')
+})
+
+it('should return undefined when the given index is out of bounds (Promise async)', async () => {
+  let program = pipe(at(25))
+
+  expect(await program(Promise.resolve(range(0, 24)))).toBeUndefined()
+  expect(await program(Promise.resolve(range(0, 24)))).toBeUndefined()
+})
+
+it('should return the element at the given index (negative) (Promise async)', async () => {
+  let program = pipe(
+    map((x: number) => String.fromCharCode(x + 65)),
+    at(-1)
+  )
+
+  expect(await program(Promise.resolve(range(0, 25)))).toBe('Z')
+  expect(await program(Promise.resolve(range(0, 25)))).toBe('Z')
+})

--- a/src/at.test.ts
+++ b/src/at.test.ts
@@ -40,7 +40,7 @@ it('should return the element at the given index (async)', async () => {
     map((x: number) => String.fromCharCode(x + 65)),
     at(25)
   )
-  
+
   expect(await program(range(0, 25))).toBe('Z')
   expect(await program(range(0, 25))).toBe('Z')
 })

--- a/src/at.ts
+++ b/src/at.ts
@@ -1,0 +1,33 @@
+import { find } from './find'
+import { isAsyncIterable } from './utils/iterator'
+import { pipe } from './pipe'
+import { toArray } from './toArray'
+import { LazyIterable } from './shared-types'
+
+export function at<T>(index: number) {
+  if (index >= 0) {
+    return function atFn(data: LazyIterable<T>) {
+      return find((_, i) => (i === index))(data)
+    }
+  }
+  
+  /**
+   * To support counting back with a negative index, the whole iteraror has to be
+   * converted to an array. Then, `Array.prototype.at` can be used. This is slow,
+   * but it helps deliver a consistent UX.
+   */
+  return function atFn(data: LazyIterable<T>) {
+    if (isAsyncIterable(data) || data instanceof Promise) {
+      return (async () => {
+        let stream = data instanceof Promise ? await data : data
+
+        let program = pipe(toArray())
+        let array = await program(stream)
+
+        return array.at(index)
+      })()
+    }
+
+    return Array.from(data).at(index)
+  }
+}

--- a/src/at.ts
+++ b/src/at.ts
@@ -7,10 +7,10 @@ import { LazyIterable } from './shared-types'
 export function at<T>(index: number) {
   if (index >= 0) {
     return function atFn(data: LazyIterable<T>) {
-      return find((_, i) => (i === index))(data)
+      return find((_, i) => i === index)(data)
     }
   }
-  
+
   /**
    * To support counting back with a negative index, the whole iteraror has to be
    * converted to an array. Then, `Array.prototype.at` can be used. This is slow,


### PR DESCRIPTION
This PR adds a new `at` feature as a continuation of the existing PR #25.

Returns the value at the given index.

```js
import { pipe, at } from 'lazy-collections'

let program = pipe(at(2))

program([1, 2, 3, 4])

// 3
```

You can also pass a negative index to `at` to count back from the end of the array or iterator.

> **Warning**: Performance may be degraded because it has to exhaust the full iterator before it can count backwards!

```js
import { pipe, at } from 'lazy-collections'

let program = pipe(at(-2))

program([1, 2, 3, 4])

// 3
```

If a value can not be found at the given index, then `undefined` will be returned.

```js
import { pipe, at } from 'lazy-collections'

let program = pipe(at(12))

program([1, 2, 3, 4])

// undefined
```

Closes: #25
Thanks, @AlexVipond!
