### PR TITLE
Ensure that the `types` are generated properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `includes` feature ([#24](https://github.com/RobinMalfait/lazy-collections/pull/24), [#29](https://github.com/RobinMalfait/lazy-collections/pull/29))
 - Add `at` feature ([#25](https://github.com/RobinMalfait/lazy-collections/pull/25), [#30](https://github.com/RobinMalfait/lazy-collections/pull/30))
 
+### Fixed
+
+- Ensure that the `types` are generated properly ([#32](https://github.com/RobinMalfait/lazy-collections/pull/32))
+
 ## [0.10.0] - 2022-08-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "format": "prettier . --write",
-    "build": "tsup ./src/index.ts --format esm --clean --minify",
+    "build": "tsup ./src/index.ts --format esm --clean --minify --dts",
     "test": "jest",
     "tdd": "jest --watchAll",
     "prepack": "npm run build"

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -4,7 +4,7 @@ import { LazyIterable } from './shared-types'
 type Fn = (...args: any) => any
 
 export function compose<T>(fn: Fn | LazyIterable<T>, ...fns: (Fn | LazyIterable<T>)[]): Fn {
-  return fns.reduce((f: Fn, g) => {
+  return (fns as Fn[]).reduce((f: Fn, g) => {
     let g_ = ensureFunction(g)
     return (...args) => f(g_(...args))
   }, ensureFunction(fn))

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -4,7 +4,7 @@ import { LazyIterable } from './shared-types'
 type Fn = (...args: any) => any
 
 export function compose<T>(fn: Fn | LazyIterable<T>, ...fns: (Fn | LazyIterable<T>)[]): Fn {
-  return (fns as Fn[]).reduce((f: Fn, g) => {
+  return (fns as Fn[]).reduce((f, g) => {
     let g_ = ensureFunction(g)
     return (...args) => f(g_(...args))
   }, ensureFunction(fn))

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -4,7 +4,7 @@ import { LazyIterable } from './shared-types'
 type Fn = (...args: any) => any
 
 export function pipe<T>(...fns: (Fn | LazyIterable<T>)[]): Fn {
-  return fns.reduceRight((f: Fn, g) => {
+  return (fns as Fn[]).reduceRight((f: Fn, g) => {
     let g_ = ensureFunction(g)
     return (...args) => f(g_(...args))
   }, ensureFunction(fns.pop()))

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -4,7 +4,7 @@ import { LazyIterable } from './shared-types'
 type Fn = (...args: any) => any
 
 export function pipe<T>(...fns: (Fn | LazyIterable<T>)[]): Fn {
-  return (fns as Fn[]).reduceRight((f: Fn, g) => {
+  return (fns as Fn[]).reduceRight((f, g) => {
     let g_ = ensureFunction(g)
     return (...args) => f(g_(...args))
   }, ensureFunction(fns.pop()))


### PR DESCRIPTION
Noticed in the insiders build that we lost type definitions—this PR restores them.

Once I added the `--dts` flag, I started getting TS errors for `pipe` and `compose`, since `reduce` and `reduceRight` only want to operate on `Fn`, not the union type. The type assertion is a decent workaround, but I don't love it—maybe you know a better way to fix.